### PR TITLE
Updating requests to 2.20.0 for CVE-2018-18074

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 six==1.10.0
-requests==2.18.4
+requests==2.20.0


### PR DESCRIPTION
The Requests package before 2.20.0 has a known vulnerability. See https://cve.mitre.org/cgi-bin/cvename.cgi?name=2018-18074