### PR TITLE
Share session between requests

### DIFF
--- a/pusher_push_notifications/__init__.py
+++ b/pusher_push_notifications/__init__.py
@@ -108,6 +108,17 @@ class PushNotifications(object):
         self.secret_key = secret_key
         self._endpoint = endpoint
 
+        session = requests.Session()
+        # We've had multiple support requests about this library not working
+        # on PythonAnywhere (a popular python deployment platform)
+        # They require that proxy servers be loaded from the environment when
+        # making requests (on their free plan).
+        # This reintroduces the proxy support that is the default in requests
+        # anyway.
+        session.proxies = _get_proxies_from_env()
+        self.session = session
+
+
     @property
     def endpoint(self):
         """Property method to calculate the correct Pusher API host"""
@@ -124,15 +135,6 @@ class PushNotifications(object):
         path = path.format(**path_params)
         url = _make_url(scheme='https', host=self.endpoint, path=path)
 
-        session = requests.Session()
-        # We've had multiple support requests about this library not working
-        # on PythonAnywhere (a popular python deployment platform)
-        # They require that proxy servers be loaded from the environment when
-        # making requests (on their free plan).
-        # This reintroduces the proxy support that is the default in requests
-        # anyway.
-        session.proxies = _get_proxies_from_env()
-
         request = requests.Request(
             method,
             url,
@@ -146,7 +148,7 @@ class PushNotifications(object):
             },
         )
 
-        response = session.send(request.prepare())
+        response = self.session.send(request.prepare())
 
         if response.status_code != 200:
             try:


### PR DESCRIPTION
Hi! It's fine (and better) to share the session instance between requests. 

https://requests.readthedocs.io/en/latest/user/advanced/
>So if you’re making several requests to the same host, the underlying TCP connection will be reused, which can result in a significant performance increase (see [HTTP persistent connection](https://en.wikipedia.org/wiki/HTTP_persistent_connection)). 

Another benefit - we get access to `beams.session` and we can configure it as we want to (our case it to add logging for the pusher beams client http requests\responses)